### PR TITLE
Add storage module with profile support in requirements

### DIFF
--- a/Hybrid/requirements.txt
+++ b/Hybrid/requirements.txt
@@ -1,5 +1,5 @@
 azure-mgmt-resource~=2.0.0rc1
 azure-mgmt-network~=2.0.0rc2
 azure-mgmt-compute~=4.0.0rc2
-azure-mgmt-storage~=2.0.0rc1
+azure-mgmt-storage~=2.0.0rc3
 haikunator

--- a/Hybrid/requirements.txt
+++ b/Hybrid/requirements.txt
@@ -1,4 +1,5 @@
 azure-mgmt-resource~=2.0.0rc1
 azure-mgmt-network~=2.0.0rc2
 azure-mgmt-compute~=4.0.0rc2
+azure-mgmt-storage~=2.0.0rc1
 haikunator


### PR DESCRIPTION
Hybrid sample requires storage module package with "profile" support. This was missing in the requirements.txt and caused failures in AzureStack